### PR TITLE
With hostname by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.radius</groupId>
     <artifactId>metrics-elasticsearch-reporter</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,27 +2,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
 
     <groupId>com.radius</groupId>
     <artifactId>metrics-elasticsearch-reporter</artifactId>
     <version>2.3.1</version>
+    <packaging>jar</packaging>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lucene.version>4.10.2</lucene.version>
         <elasticsearch.version>1.4.2</elasticsearch.version>
     </properties>
 
-
-    <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
     <name>metrics-elasticsearch-reporter</name>
     <description>Reporter for the metrics library which reports into Elasticsearch</description>
     <inceptionYear>2013</inceptionYear>
 
     <scm>
-        <connection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git</connection>
-        <developerConnection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git</developerConnection>
-        <url>http://github.com/elasticsearch/elasticsearch-metrics-reporter</url>
+        <connection>scm:git:git@github.com:RadiusIntelligence/elasticsearch-metrics-reporter-java.git</connection>
+        <developerConnection>scm:git:git@github.com:RadiusIntelligence/elasticsearch-metrics-reporter-java.git</developerConnection>
+        <url>http://github.com/RadiusIntelligence/elasticsearch-metrics-reporter-java</url>
     </scm>
 
     <licenses>
@@ -33,22 +38,9 @@
         </license>
     </licenses>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-
-    <repositories>
-        <repository>
-            <id>sonatype</id>
-            <url>http://oss.sonatype.org/content/repositories/releases/</url>
-        </repository>
-    </repositories>
-
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/elasticsearchi/elasticsearch-metrics-reporter-java/issues/</url>
+        <url>https://github.com/RadiusIntelligence/elasticsearch-metrics-reporter-java/issues/</url>
     </issueManagement>
 
     <build>
@@ -58,6 +50,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
+                    <debug>true</debug>
                     <source>1.7</source>
                     <target>1.7</target>
                 </configuration>
@@ -89,6 +82,7 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.4.3</version>
         </dependency>
+        <!-- /// TEST DEPENDENCIES /// -->
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>
@@ -139,6 +133,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>sonatype</id>
+            <url>http://oss.sonatype.org/content/repositories/releases/</url>
+        </repository>
+    </repositories>
 
     <distributionManagement>
         <repository>

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -79,6 +79,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         /**
          * Inject your custom definition of how time passes. Usually the default clock is sufficient
          */
+        @SuppressWarnings("unused")
         public Builder withClock(Clock clock) {
             this.clock = clock;
             return this;
@@ -131,6 +132,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         /**
          * The timeout to wait for until a connection attempt is and the next host is tried
          */
+        @SuppressWarnings("unused")
         public Builder timeout(int timeout) {
             this.timeout = timeout;
             return this;
@@ -156,6 +158,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         /**
          * The bulk size per request, defaults to 2500 (as metrics are quite small)
          */
+        @SuppressWarnings("unused")
         public Builder bulkSize(int bulkSize) {
             this.bulkSize = bulkSize;
             return this;
@@ -187,8 +190,6 @@ public class ElasticsearchReporter extends ScheduledReporter {
 
         /**
          * Additional fields to be included for each metric
-         * @param additionalFields
-         * @return
          */
         public Builder additionalFields(Map<String, Object> additionalFields) {
             this.additionalFields = additionalFields;
@@ -197,9 +198,8 @@ public class ElasticsearchReporter extends ScheduledReporter {
 
         /**
          * Custom method. On save log start up time.
-         *
-         * @return Builder
          */
+        @SuppressWarnings("unused")
         public Builder saveEntryOnInstantiation(boolean saveEntryOnInstantiation) {
             this.saveEntryOnInstantiation = saveEntryOnInstantiation;
             return this;
@@ -330,12 +330,12 @@ public class ElasticsearchReporter extends ScheduledReporter {
                 return;
             }
 
-            List<JsonMetric> percolationMetrics = new ArrayList<JsonMetric>();
+            List<JsonMetric> percolationMetrics = new ArrayList<>();
             AtomicInteger entriesWritten = new AtomicInteger(0);
 
             for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
                 if (entry.getValue().getValue() != null) {
-                    JsonMetric jsonMetric = new JsonGauge(name(prefix, entry.getKey()), timestamp, entry.getValue());
+                    JsonGauge jsonMetric = new JsonGauge(name(prefix, entry.getKey()), timestamp, entry.getValue());
                     connection = writeJsonMetricAndRecreateConnectionIfNeeded(jsonMetric, connection, entriesWritten);
                     addJsonMetricToPercolationIfMatching(jsonMetric, percolationMetrics);
                 }
@@ -424,10 +424,10 @@ public class ElasticsearchReporter extends ScheduledReporter {
         HttpURLConnection connection = openConnection("/" + currentIndexName + "/" + jsonMetric.type() + "/_percolate", "POST");
         if (connection == null) {
             LOGGER.error("Could not connect to any configured elasticsearch instances for percolation: {}", Arrays.asList(hosts));
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
-        Map<String, Object> data = new HashMap<String, Object>(1);
+        Map<String, Object> data = new HashMap<>(1);
         data.put("doc", jsonMetric);
         objectMapper.writeValue(connection.getOutputStream(), data);
         closeConnection(connection);
@@ -436,10 +436,12 @@ public class ElasticsearchReporter extends ScheduledReporter {
             throw new RuntimeException("Error percolating " + jsonMetric);
         }
 
-        Map<String, Object> input = objectMapper.readValue(connection.getInputStream(), Map.class);
-        List<String> matches = new ArrayList<String>();
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> input = objectMapper.readValue(connection.getInputStream(), Map.class);
+        List<String> matches = new ArrayList<>();
         if (input.containsKey("matches") && input.get("matches") instanceof List) {
-            List<Map<String, String>> foundMatches = (List<Map<String, String>>) input.get("matches");
+            @SuppressWarnings("unchecked")
+            final List<Map<String, String>> foundMatches = (List<Map<String, String>>) input.get("matches");
             for (Map<String, String> entry : foundMatches) {
                 if (entry.containsKey("_id")) {
                     matches.add(entry.get("_id"));

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -547,6 +547,10 @@ public class ElasticsearchReporter extends ScheduledReporter {
             if (isTemplateMissing) {
                 LOGGER.debug("No metrics template found in elasticsearch. Adding...");
                 HttpURLConnection putTemplateConnection = openConnection( "/_template/metrics_template", "PUT");
+                if (null == putTemplateConnection) {
+                    LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.asList(hosts));
+                    return;
+                }
                 JsonGenerator json = new JsonFactory().createGenerator(putTemplateConnection.getOutputStream());
                 json.writeStartObject();
                 json.writeStringField("template", index + "*");

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -66,7 +66,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         private String hostName;
         private boolean sendHostname = true;
         private Map<String, Object> additionalFields;
-        private boolean saveEntryOnInstantiation = false;
+        private boolean saveEntryOnInstantiation;
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -262,8 +262,8 @@ public class ElasticsearchReporter extends ScheduledReporter {
     private MetricFilter percolationFilter;
     private Notifier notifier;
     private String currentIndexName;
-    private SimpleDateFormat indexDateFormat = null;
-    private boolean checkedForIndexTemplate = false;
+    private SimpleDateFormat indexDateFormat;
+    private boolean checkedForIndexTemplate;
     private boolean saveEntryOnInstantiation;
 
     public ElasticsearchReporter(Builder config)

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -95,6 +95,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertThat(mapping.get("index").toString(), is("not_analyzed"));
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, Object> getAsMap(Map<String, Object> map, String key) {
         assertThat(map, hasKey(key));
         assertThat(map.get(key), instanceOf(Map.class));
@@ -328,7 +329,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
 
     private class SimpleNotifier implements Notifier {
 
-        public Map<String, JsonMetrics.JsonMetric> metrics = new HashMap<String, JsonMetrics.JsonMetric>();
+        public Map<String, JsonMetrics.JsonMetric> metrics = new HashMap<>();
 
         @Override
         public void notify(JsonMetrics.JsonMetric jsonMetric, String match) {
@@ -369,7 +370,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
     }
 
     private ElasticsearchReporter.Builder createElasticsearchReporterBuilder() {
-        Map<String, Object> additionalFields = new HashMap<String, Object>();
+        Map<String, Object> additionalFields = new HashMap<>();
         additionalFields.put("host", "localhost");
         return ElasticsearchReporter.forRegistry(registry)
                 .hosts("localhost:" + getPortOfRunningNode())

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,6 +63,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
     @Before
     public void setup() throws IOException {
         elasticsearchReporter = createElasticsearchReporterBuilder().build();
+        expectedHostname = InetAddress.getLocalHost().getHostName();
     }
 
     @Test
@@ -142,7 +144,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();
         assertTimestamp(hit);
         assertKey(hit, name(prefix, counterName));
-        assertKey(hit, "host", "localhost");
+        assertKey(hit, "host", expectedHostname);
     }
 
     @Test
@@ -162,7 +164,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         .has("max", 40)
         .has("min", 20)
         .has("mean", 30.0)
-        .has("host", "localhost");
+        .has("host", expectedHostname);
     }
 
     @Test
@@ -179,7 +181,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertTimestamp(hit);
         assertKeyAndMap(hit, prefix + ".foo.bar")
         .has("count", 30)
-        .has("host", "localhost");
+        .has("host", expectedHostname);
     }
 
     @Test
@@ -197,7 +199,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertTimestamp(hit);
         assertKeyAndMap(hit, prefix + ".foo.bar")
         .has("count", 1)
-        .has("host", "localhost");
+        .has("host", expectedHostname);
     }
 
     @Test
@@ -216,7 +218,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();
         assertTimestamp(hit);
         assertKey(hit, prefix + ".foo.bar", 1234);
-        assertKey(hit, "host", "localhost");
+        assertKey(hit, "host", expectedHostname);
     }
 
     @Test
@@ -383,7 +385,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
 
     private ElasticsearchReporter.Builder createElasticsearchReporterBuilder() {
         Map<String, Object> additionalFields = new HashMap<>();
-        additionalFields.put("host", "localhost");
+        additionalFields.put("host", expectedHostname);
         return ElasticsearchReporter.forRegistry(registry)
                 .hosts("localhost:" + getPortOfRunningNode())
                 .prefixedWith(prefix)

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -104,7 +104,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatTemplateIsNotOverWritten() throws Exception {
-        client().admin().indices().preparePutTemplate("metrics_template").setTemplate("foo*").setSettings(String.format("{ \"index.number_of_shards\" : \"1\"}")).execute().actionGet();
+        client().admin().indices().preparePutTemplate("metrics_template").setTemplate("foo*").setSettings("{ \"index.number_of_shards\" : \"1\"}").execute().actionGet();
         //client().admin().cluster().prepareHealth().setWaitForGreenStatus();
 
         elasticsearchReporter = createElasticsearchReporterBuilder().build();

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -54,9 +54,10 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
 
     private ElasticsearchReporter elasticsearchReporter;
     private MetricRegistry registry = new MetricRegistry();
-    private String index = randomAsciiOfLength(12).toLowerCase();
+    private String index = randomAsciiOfLength(12).replaceAll("[^A-Za-z0-9]", "_").toLowerCase();
     private String indexWithDate = String.format("%s-%s-%02d", index, Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH)+1);
-    private String prefix = randomAsciiOfLength(12).toLowerCase();
+    private String prefix = randomAsciiOfLength(12).replaceAll("[^A-Za-z0-9]", "_").toLowerCase();
+    private String expectedHostname;
 
     @Before
     public void setup() throws IOException {


### PR DESCRIPTION
It is still at risk of ND test failures because the Elasticsearch base test seems to generate indices with what look like unicode characters in the name. I can't for the life of me track down what is causing that.

But the tests _do_ pass now. I didn't wire in a test for Philip's previous change, but it's (1) unlikely to break (2) unlikely to have a bad interaction with a new feature.

I also actually wired it into the app and ensured that it worked in Real Life&trade; as much as it worked in the tests.