### PR TITLE
Discover cluster members

### DIFF
--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -370,7 +370,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         try {
             HttpURLConnection connection = openConnection("/_bulk", "POST");
             if (connection == null) {
-                LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.asList(hosts));
+                LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.toString(hosts));
                 return;
             }
 
@@ -443,7 +443,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
                 HttpURLConnection connection = openConnection("/_bulk", "POST");
                 if (connection == null) {
                     LOGGER.error("Could not connect to any configured elasticsearch instances: {}",
-                            Arrays.asList(hosts));
+                            Arrays.toString(hosts));
                     return;
                 }
 
@@ -467,7 +467,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
     private List<String> getPercolationMatches(JsonMetric jsonMetric) throws IOException {
         HttpURLConnection connection = openConnection("/" + currentIndexName + "/" + jsonMetric.type() + "/_percolate", "POST");
         if (connection == null) {
-            LOGGER.error("Could not connect to any configured elasticsearch instances for percolation: {}", Arrays.asList(hosts));
+            LOGGER.error("Could not connect to any configured elasticsearch instances for percolation: {}", Arrays.toString(hosts));
             return Collections.emptyList();
         }
 
@@ -583,7 +583,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         try {
             HttpURLConnection connection = openConnection( "/_template/metrics_template", "HEAD");
             if (connection == null) {
-                LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.asList(hosts));
+                LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.toString(hosts));
                 return;
             }
             connection.disconnect();
@@ -666,7 +666,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         if (null == conn) {
             // openConnection logs the error, so just give what they gave and wish them luck
             LOGGER.warn("I am returning bootstrap-hosts because I could not connect to any of them: {}",
-                    Arrays.asList(bootstrapHosts));
+                    Arrays.toString(bootstrapHosts));
             return bootstrapHosts;
         }
         final List<String> discoveredHosts = new ArrayList<>();

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -695,8 +695,6 @@ public class ElasticsearchReporter extends ScheduledReporter {
             conn.disconnect();
         }
         LOGGER.info("Discovered cluster members: {}", discoveredHosts);
-        final String[] results = new String[discoveredHosts.size()];
-        discoveredHosts.toArray(results);
-        return results;
+        return discoveredHosts.toArray(new String[discoveredHosts.size()]);
     }
 }

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -289,7 +289,11 @@ public class ElasticsearchReporter extends ScheduledReporter {
     public ElasticsearchReporter(Builder config)
             throws IOException {
         super(config.registry, "elasticsearch-reporter", config.filter, config.rateUnit, config.durationUnit);
-        this.hosts = (config.discoverClusterMembers) ? discoverClusterMembers(config.hosts) : config.hosts;
+        if (config.discoverClusterMembers) {
+            this.hosts = discoverClusterMembers(config.hosts);
+        } else {
+            this.hosts = config.hosts;
+        }
         this.index = config.index;
         this.bulkSize = config.bulkSize;
         this.clock = config.clock;

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -28,9 +28,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.common.joda.time.format.ISODateTimeFormat;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -41,6 +38,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -402,11 +400,10 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
     }
 
     private int getPortOfRunningNode() {
-        TransportAddress transportAddress = internalCluster().getInstance(HttpServerTransport.class).boundAddress().boundAddress();
-        if (transportAddress instanceof InetSocketTransportAddress) {
-            return ((InetSocketTransportAddress) transportAddress).address().getPort();
-        }
-        throw new ElasticsearchException("Could not find running tcp port");
+        final InetSocketAddress[] addresses = internalCluster().httpAddresses();
+        assertNotNull("Must not return NULL httpAddresses", addresses);
+        assertNotEquals("httpAddress must not be empty", 0, addresses.length);
+        return addresses[0].getPort();
     }
 
     private ElasticsearchReporter.Builder createElasticsearchReporterBuilder() {

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -80,7 +80,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         reportAndRefresh();
 
         // somehow the cluster state is not immediately updated... need to check
-        Thread.sleep(200);
+        Thread.sleep(500);
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().setRoutingTable(false)
                 .setLocal(false)
                 .setNodes(true)


### PR DESCRIPTION
Does what it says on the box.

Cherry picked in Philip's change to propagate `additionalFields` with the startup metric.

I tested it in a multi-node, kill one, then bring it back situ and it behaved exactly as expected (bootstraped with only one address, of course).